### PR TITLE
Hidden reply button in subcomments when not joined

### DIFF
--- a/client/components/comment.vue
+++ b/client/components/comment.vue
@@ -41,7 +41,7 @@
         </div>
         <div v-if="!isDeleted && !editting && !writeSubcomment" class="d-flex">
           <div
-            v-if="$auth.user"
+            v-if="$auth.user && joined"
             class="reply mr-4"
             @click="showSubcomment()"
           >
@@ -149,13 +149,20 @@ export default {
       editText: '',
       isDeleted: false,
       sending: false,
-      subcommentError: undefined
+      subcommentError: undefined,
+      joined: false
     }
   },
 
-  beforeMount () {
+  async beforeMount () {
     this.commentText = this.text
     this.isDeleted = this.deleted
+
+    // Check if user is joined to enable replies
+    const res = await this.$axios.get(`/api/station/id/${this.$route.params.station}`)
+    const { joined } = res.data
+
+    this.$set(this, 'joined', joined)
   },
 
   methods: {


### PR DESCRIPTION
Fixes #62 by hiding the reply button, user can still edit and delete past comments on station even when the user has left